### PR TITLE
View model binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+packages/

--- a/LC Points/LC Points.Shared/App.xaml.cs
+++ b/LC Points/LC Points.Shared/App.xaml.cs
@@ -18,8 +18,8 @@ using Windows.UI.Xaml.Navigation;
 using Facebook;
 using LC_Points.Model;
 
-
 // The Blank Application template is documented at http://go.microsoft.com/fwlink/?LinkId=234227
+using LC_Points.Services;
 
 namespace LC_Points
 {
@@ -28,8 +28,9 @@ namespace LC_Points
     /// </summary>
     public sealed partial class App : Application
     {
+        public static IRepository<ScoreModel> ScoresRepository = new ScoresRepository();
 
-        
+
 #if WINDOWS_PHONE_APP
         private TransitionCollection transitions;
 #endif

--- a/LC Points/LC Points.Shared/LC Points.Shared.projitems
+++ b/LC Points/LC Points.Shared/LC Points.Shared.projitems
@@ -18,6 +18,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Converter\BoolToNonVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converter\BoolToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\ScoreModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\IRepository.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\ScoresRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\AboutViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\MainViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\ViewSubjectGradeViewModel.cs" />

--- a/LC Points/LC Points.Shared/Services/IRepository.cs
+++ b/LC Points/LC Points.Shared/Services/IRepository.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.ObjectModel;
+
+namespace LC_Points.Services
+{
+    public interface IRepository<T>
+    {
+        ObservableCollection<T> Collection { get; }
+
+        void Add(T entity);
+
+        void Remove(T entity);
+
+        void Clear();
+
+        int Count { get; }
+    }
+}

--- a/LC Points/LC Points.Shared/Services/ScoresRepository.cs
+++ b/LC Points/LC Points.Shared/Services/ScoresRepository.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using LC_Points.Model;
+
+namespace LC_Points.Services
+{
+    sealed class ScoresRepository : IRepository<ScoreModel>, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private readonly ObservableCollection<ScoreModel> _collection = new ObservableCollection<ScoreModel>();
+        private int _count;
+
+        public ScoresRepository()
+        {
+            _collection.CollectionChanged += (sender, args) =>
+            {
+                this.Count = _collection.Count;
+            };
+        }
+
+        public ObservableCollection<ScoreModel> Collection
+        {
+            get { return _collection; }
+        }
+
+
+        public void Add(ScoreModel entity)
+        {
+            _collection.Add(entity);
+        }
+
+        public void Remove(ScoreModel entity)
+        {
+            _collection.Remove(entity);
+        }
+
+        public void Clear()
+        {
+            _collection.Clear();
+        }
+
+        public int Count
+        {
+            get { return _count; }
+            set
+            {
+                if (_count != value)
+                {
+                    _count = value;
+                    this.NotifyPropertyChanged();
+                }
+            }
+        }
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            if (this.PropertyChanged != null)
+            {
+                this.PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+    }
+}

--- a/LC Points/LC Points.Shared/ViewModel/MainViewModel.cs
+++ b/LC Points/LC Points.Shared/ViewModel/MainViewModel.cs
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using Windows.UI.Xaml.Controls;
 using System.Linq;
 using Windows.UI.Popups;
+using LC_Points.Services;
 
 namespace LC_Points.ViewModel
 {
@@ -23,9 +24,9 @@ namespace LC_Points.ViewModel
     /// See http://www.galasoft.ch/mvvm
     /// </para>
     /// </summary>
-    public class MainViewModel : ViewModelBase 
+    public class MainViewModel : ViewModelBase
     {
-
+        private readonly IRepository<ScoreModel> _repository = App.ScoresRepository; 
      
         /// <summary>
         /// Initializes a new instance of the MainViewModel class.
@@ -37,15 +38,8 @@ namespace LC_Points.ViewModel
             InitSubjectTypes();
             InitOrdinaryGradePairs();
             InitHigherGradePairs();
-
-            ViewSubjectGradeViewModelProperty = new ViewSubjectGradeViewModel();
-
-
         }
 
-
-        private ViewSubjectGradeViewModel _viewSubjectGradeViewModel;
-        public ViewSubjectGradeViewModel ViewSubjectGradeViewModelProperty { get; set; }
 
         public List<ScoreModel> Subjects { get; set; }
         public List<StringKeyValue> HigherGradePointKV { get; set; }
@@ -195,10 +189,9 @@ namespace LC_Points.ViewModel
          
             SelectedPoints = IsHigher ? SelectedHigherGrade.Value : SelectedOrdinaryGrade.Value;
 
-            ViewSubjectGradeViewModelProperty.AddedSubjectGradePairs.Add(new ScoreModel() { Subject = SelectedSubjectName, Points = SelectedPoints });
+            _repository.Add(new ScoreModel() {Subject = SelectedSubjectName, Points = SelectedPoints});
 
-
-            if (ViewSubjectGradeViewModelProperty.AddedSubjectGradePairs.Count <= 6)
+            if (_repository.Count <= 6)
             {
                 CalculateLeavingCertPoints();
             }
@@ -215,7 +208,7 @@ namespace LC_Points.ViewModel
             //IF 6 subjects and grades
             //add 6 grade points
             //output result of addition
-            TotalPoints = ViewSubjectGradeViewModelProperty.AddedSubjectGradePairs.Sum(x => x.Points);
+            TotalPoints = _repository.Collection.Sum(x => x.Points);
 
         }
 
@@ -270,7 +263,7 @@ namespace LC_Points.ViewModel
                     clearGradesCommand = new RelayCommand(() =>
                     {
                         //call to empty collection items
-                        ViewSubjectGradeViewModelProperty.AddedSubjectGradePairs.Clear();
+                        _repository.Clear();
                         TotalPoints = 0;
 
                     });

--- a/LC Points/LC Points.Shared/ViewModel/ViewSubjectGradeViewModel.cs
+++ b/LC Points/LC Points.Shared/ViewModel/ViewSubjectGradeViewModel.cs
@@ -5,25 +5,26 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
+using LC_Points.Services;
 
 namespace LC_Points.ViewModel
 {
-    public class ViewSubjectGradeViewModel 
+    public class ViewSubjectGradeViewModel
     {
+        private readonly IRepository<ScoreModel> _repository = App.ScoresRepository;
 
-              
-         /// <summary>
+        /// <summary>
         /// Initializes a new instance of the ViewSubjectGradeViewModel class.
         /// </summary>
         public ViewSubjectGradeViewModel()
         {
 
-            AddedSubjectGradePairs = new ObservableCollection<ScoreModel>();
-     
         }
 
 
-        public ObservableCollection<ScoreModel> AddedSubjectGradePairs { get; set; }       
-        
+        public ObservableCollection<ScoreModel> AddedSubjectGradePairs
+        {
+            get { return _repository.Collection; }
+        }
     }
 }

--- a/LC Points/LC Points.WindowsPhone/View/MainPage.xaml
+++ b/LC Points/LC Points.WindowsPhone/View/MainPage.xaml
@@ -153,7 +153,6 @@
                               IsCompact="False"
                               Label="Clear All" />
                 <AppBarButton x:Name="ViewListAppBarButton"
-                              Command="{Binding Path=AddGradeCommand}"
                               Icon="ViewAll"
                               IsCompact="False"
                               IsEnabled="{Binding ButtonEnabled,


### PR DESCRIPTION
The issue was the data between the MainViewModel and the ViewSubjectGradeViewModel was not referencing the same data store. I created a simple repository that both view models reference so when data is added from MainViewModel it can is available to other classes. Navigation to ViewSubjectGradePage would instantiate a new ViewSubjectGradeViewModel which was starting out with a fresh data store. This has been corrected to use the new repository.

Also fixed a bug where the Command on a button was set when it shouldn't have been there. This was causing extra data to be added during navigation.
